### PR TITLE
Add emitdeclarationonly

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+.npm
+.npmrc
+.config/
+
+node_modules
+storybook-static
+.storybook
+example

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ctoec/component-library",
-	"version": "0.0.12",
+	"version": "0.0.9",
 	"description": "React Component Library for OEC branded web applications",
 	"homepage": "https://github.com/ctoec/component-library#readme",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ctoec/component-library",
-	"version": "0.0.9",
+	"version": "0.0.12",
 	"description": "React Component Library for OEC branded web applications",
 	"homepage": "https://github.com/ctoec/component-library#readme",
 	"repository": {
@@ -89,7 +89,7 @@
 		"storybook-react-router": "^1.0.8",
 		"style-loader": "^1.2.1"
 	},
-	"engines": { 
-		"node": "^12" 
+	"engines": {
+		"node": "^12"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"storybook": "start-storybook -p 9009 -s public",
 		"build-storybook": "build-storybook -s public",
 		"build": "rm -rf dist && NODE_ENV=production yarn run build:types && yarn run build:js",
-		"build:types": "tsc --emitDeclarationOnly",
+		"build:types": "tsc -p tsconfig.build.json",
 		"build:js": "babel src --out-dir dist --extensions \".ts,.tsx\" --source-maps inline  --copy-files --ignore \"**/*.stories.tsx,**/*.test.tsx,.storybook\""
 	},
 	"keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ctoec/component-library",
-	"version": "0.0.11",
+	"version": "0.0.12",
 	"description": "React Component Library for OEC branded web applications",
 	"homepage": "https://github.com/ctoec/component-library#readme",
 	"repository": {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -16,7 +16,7 @@
 		"moduleResolution": "node",
 		"resolveJsonModule": true,
 		"isolatedModules": true,
-		"noEmit": true
+		"emitDeclarationOnly": true
 	},
 	"include": ["./src"],
 	"exclude": ["./node_modules", "./dist", "**/*.stories.tsx", "**/*.test.tsx"]


### PR DESCRIPTION
Installing react scripts overwrites the tsconfig.json file, so I sneakily added one just for the type publishing step.  Also bumped version number back to reflect what version we'd actually be publishing to npm, accounting for the failed attempts.