### PR TITLE
Fix storybook GitHub Action permissions

### DIFF
--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -19,4 +19,4 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn run deploy-storybook
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -18,3 +18,5 @@ jobs:
       - run: npm install -g yarn
       - run: yarn install --frozen-lockfile
       - run: yarn run deploy-storybook
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -5,7 +5,7 @@ name: Storybook Deploy to GitHub Pages
 on:
   push:
     branches:
-      - fix-storybook-github-action
+      - base
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -5,7 +5,7 @@ name: Storybook Deploy to GitHub Pages
 on:
   push:
     branches:
-      - base
+      - fix-storybook-github-action
 
 jobs:
   build-and-deploy:
@@ -17,6 +17,6 @@ jobs:
           node-version: 12
       - run: npm install -g yarn
       - run: yarn install --frozen-lockfile
-      - run: yarn run deploy-storybook
+      - run: yarn run deploy-storybook:ci
         env:
-          GH_TOKEN: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -18,5 +18,3 @@ jobs:
       - run: npm install -g yarn
       - run: yarn install --frozen-lockfile
       - run: yarn run deploy-storybook
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -5,7 +5,7 @@ name: Storybook Deploy to GitHub Pages
 on:
   push:
     branches:
-      - base
+      - fix-storybook-github-action
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -18,3 +18,5 @@ jobs:
       - run: npm install -g yarn
       - run: yarn install --frozen-lockfile
       - run: yarn run deploy-storybook
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -18,5 +18,5 @@ jobs:
       - run: npm install -g yarn
       - run: yarn install --frozen-lockfile
       - run: yarn run deploy-storybook
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ You can check it out live at http://ctoec.github.io/component-library/.
 ### Deploying Storybook
 These Storybook deployments are handled with the `storybook-deployer` package, using the `gh-pages` branch of this repository as the site's source.  Additionally, all commits to our core `base` branch will trigger an associated GitHub Action that automatically updates our Storybook site.  So it'll be kept up to date with the latest state of our library at all times!
 
-Regardless, if there's ever a need for the site to be updated manually, the following command should be run from project root:
+Regardless, if there's ever a need for the site to be updated *manually*, the following command should be run from project root:
 ```.sh
-yarn run deploy-storybook
+yarn run deploy-storybook:manual
 ```
 
 ## To use this library

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ These Storybook deployments are handled with the `storybook-deployer` package, u
 
 Regardless, if there's ever a need for the site to be updated *manually*, the following command should be run from project root:
 ```.sh
-yarn run deploy-storybook:manual
+yarn run deploy-storybook
 ```
 
 ## To use this library

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"test": "react-scripts test",
 		"storybook": "start-storybook -p 9009 -s public",
 		"build-storybook": "build-storybook -s public",
-		"deploy-storybook": "storybook-to-ghpages --branch 'gh-pages' --out=storybook-static --ci --host-token-env-variable=GITHUB_TOKEN",
+		"deploy-storybook": "storybook-to-ghpages --branch 'gh-pages' --out=storybook-static --ci",
 		"build": "rm -rf dist && NODE_ENV=production yarn run build:types && yarn run build:js",
 		"build:types": "tsc -p tsconfig.build.json",
 		"build:js": "babel src --out-dir dist --extensions \".ts,.tsx\" --source-maps inline  --copy-files --ignore \"**/*.stories.tsx,**/*.test.tsx,.storybook\""

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"test": "react-scripts test",
 		"storybook": "start-storybook -p 9009 -s public",
 		"build-storybook": "build-storybook -s public",
-		"deploy-storybook": "storybook-to-ghpages --branch 'gh-pages' --out=storybook-static --ci",
+		"deploy-storybook": "storybook-to-ghpages --branch 'gh-pages' --out=storybook-static --ci --host-token-env-variable=GITHUB_TOKEN",
 		"build": "rm -rf dist && NODE_ENV=production yarn run build:types && yarn run build:js",
 		"build:types": "tsc -p tsconfig.build.json",
 		"build:js": "babel src --out-dir dist --extensions \".ts,.tsx\" --source-maps inline  --copy-files --ignore \"**/*.stories.tsx,**/*.test.tsx,.storybook\""

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
 		"test": "react-scripts test",
 		"storybook": "start-storybook -p 9009 -s public",
 		"build-storybook": "build-storybook -s public",
-		"deploy-storybook": "storybook-to-ghpages --out=storybook-static --ci",
-		"deploy-storybook:manual": "storybook-to-ghpages --out=storybook-static",
+		"deploy-storybook": "storybook-to-ghpages --out=storybook-static",
+		"deploy-storybook:ci": "storybook-to-ghpages --out=storybook-static --ci --host-token-env-variable=GITHUB_TOKEN",
 		"build": "rm -rf dist && NODE_ENV=production yarn run build:types && yarn run build:js",
 		"build:types": "tsc -p tsconfig.build.json",
 		"build:js": "babel src --out-dir dist --extensions \".ts,.tsx\" --source-maps inline  --copy-files --ignore \"**/*.stories.tsx,**/*.test.tsx,.storybook\""

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"test": "react-scripts test",
 		"storybook": "start-storybook -p 9009 -s public",
 		"build-storybook": "build-storybook -s public",
-		"deploy-storybook": "storybook-to-ghpages --branch 'gh-pages' --out=storybook-static",
+		"deploy-storybook": "storybook-to-ghpages --branch 'gh-pages' --out=storybook-static --ci",
 		"build": "rm -rf dist && NODE_ENV=production yarn run build:types && yarn run build:js",
 		"build:types": "tsc -p tsconfig.build.json",
 		"build:js": "babel src --out-dir dist --extensions \".ts,.tsx\" --source-maps inline  --copy-files --ignore \"**/*.stories.tsx,**/*.test.tsx,.storybook\""

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"storybook": "start-storybook -p 9009 -s public",
 		"build-storybook": "build-storybook -s public",
 		"deploy-storybook": "storybook-to-ghpages --out=storybook-static --ci",
+		"deploy-storybook:manual": "storybook-to-ghpages --out=storybook-static",
 		"build": "rm -rf dist && NODE_ENV=production yarn run build:types && yarn run build:js",
 		"build:types": "tsc -p tsconfig.build.json",
 		"build:js": "babel src --out-dir dist --extensions \".ts,.tsx\" --source-maps inline  --copy-files --ignore \"**/*.stories.tsx,**/*.test.tsx,.storybook\""

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"test": "react-scripts test",
 		"storybook": "start-storybook -p 9009 -s public",
 		"build-storybook": "build-storybook -s public",
-		"deploy-storybook": "storybook-to-ghpages --branch 'gh-pages' --out=storybook-static --ci",
+		"deploy-storybook": "storybook-to-ghpages --out=storybook-static --ci",
 		"build": "rm -rf dist && NODE_ENV=production yarn run build:types && yarn run build:js",
 		"build:types": "tsc -p tsconfig.build.json",
 		"build:js": "babel src --out-dir dist --extensions \".ts,.tsx\" --source-maps inline  --copy-files --ignore \"**/*.stories.tsx,**/*.test.tsx,.storybook\""


### PR DESCRIPTION
Specify GitHub actor and token as an environment variable when running `yarn run deploy-storybook:ci`, so that `storybook-deployer` has the necessary permissions to push to GitHub.