### PR TITLE
Clean, working tab-based form page

### DIFF
--- a/src/components/TabNav/TabNav.tsx
+++ b/src/components/TabNav/TabNav.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import cx from 'classnames';
 import { useHistory } from 'react-router';
 
@@ -18,18 +18,13 @@ export const TabNav: React.FC<TabNavProps> = ({ items, activeId }) => {
 	const [activeTabIndex, setActiveTabIndex] = useState(startingIndex < 0 ? 0 : startingIndex);
 	const history = useHistory();
 
-	useEffect(() => {
-		const activeIndex = items.findIndex((item) => item.id === activeId);
-		const activeIndexOrCurrent = activeIndex < 0 ? activeTabIndex : activeIndex;
-		setActiveTabIndex(activeIndexOrCurrent);
-	}, [activeId, activeTabIndex, items]);
-
-	useEffect(() => {
-		history.push(`#${items[activeTabIndex].id}`);
-	}, [activeTabIndex, history, items]);
-
+	// Cleanest way to handle both tab switching and pushing to history
+	// Don't need to use effects because we don't have to actually
+	// run functions after the DOM renders.
+	// This prevents getting caught in infinite state loops.
 	const onClick = (index: number) => {
-		setActiveTabIndex(index);
+        setActiveTabIndex(index);
+        history.push(`#${items[activeTabIndex].id}`);
 	};
 
 	const tabs = items.map(({ text }, index) => (

--- a/src/components/TabNav/TabNav.tsx
+++ b/src/components/TabNav/TabNav.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import cx from 'classnames';
-import { useHistory } from 'react-router';
 
 export type TabItemProps = {
 	id: string;
@@ -16,15 +15,13 @@ export type TabNavProps = {
 export const TabNav: React.FC<TabNavProps> = ({ items, activeId }) => {
 	const startingIndex = items.findIndex((item) => item.id === activeId);
 	const [activeTabIndex, setActiveTabIndex] = useState(startingIndex < 0 ? 0 : startingIndex);
-	const history = useHistory();
 
-	// Cleanest way to handle both tab switching and pushing to history
+	// Cleanest way to handle tab switching.
 	// Don't need to use effects because we don't have to actually
 	// run functions after the DOM renders.
 	// This prevents getting caught in infinite state loops.
 	const onClick = (index: number) => {
         setActiveTabIndex(index);
-        history.push(`#${items[activeTabIndex].id}`);
 	};
 
 	const tabs = items.map(({ text }, index) => (

--- a/src/components/TabNav/_index.scss
+++ b/src/components/TabNav/_index.scss
@@ -39,5 +39,10 @@
 			background-color: #ececec;
 			color: $theme-color-primary;
 		}
+		&:focus {
+			cursor: pointer;
+			background-color: #ececec;
+			color: $theme-color-primary;
+		}
 	}
 }

--- a/src/components/TabNav/_index.scss
+++ b/src/components/TabNav/_index.scss
@@ -34,12 +34,7 @@
 			color: #ffffff;
 		}
 
-		&:hover {
-			cursor: pointer;
-			background-color: #ececec;
-			color: $theme-color-primary;
-		}
-		&:focus {
+		&:hover, &:focus {
 			cursor: pointer;
 			background-color: #ececec;
 			color: $theme-color-primary;

--- a/src/components/TabNav/_index.scss
+++ b/src/components/TabNav/_index.scss
@@ -36,6 +36,8 @@
 
 		&:hover {
 			cursor: pointer;
+			background-color: #ececec;
+			color: $theme-color-primary;
 		}
 	}
 }


### PR DESCRIPTION
Lengthy description here (not totally necessary to read, just covers what I found and my rationale for the fixes I did).

Problems with current approach:
- The useEffect hook to get the currently seen tab uses identically
equal comparisons to the activeId passed into the TabNav during
instantiation--this is *never changed*, and so the hook literally
prevents a user from switching tabs because it inevitably
always resets the currently active tab to the initial start tab.
- The history hook as an effect causes infinite rendering and a
page freeze/crash. Because history is a dependency of the effect,
which gets called every frame of rendering, the page is forever
occupied pushing the same index tab into itself over and over
again because it thinks its continually getting updated information.
History pushes work better in the onClick method because we then
we only have to log changes to the viewed tab rather than push
something into the router every render frame.

We don't actually need to run any code after the DOM renders,
which means we shouldn't really be using an effect hook.
We can still leverage the state functionality of react
by just allowing the click event itself to set the tab index.
This still lets the clicked tab send its index to the TabNav panel
to display the right content.