### PR TITLE
Add value to checkbox

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -8,6 +8,8 @@ export type CheckboxProps = {
 	defaultValue?: boolean;
 	className?: string;
 	disabled?: boolean;
+	// Needs a value if it's not in a checkbox group
+	value?: string | undefined;
 	name?: string;
 } & Omit<HTMLAttributes<HTMLInputElement>, 'onChange' | 'defaultValue'>;
 
@@ -18,6 +20,7 @@ export function Checkbox({
 	id,
 	text,
 	onChange,
+	value,
 	defaultValue,
 	className,
 	disabled,
@@ -28,6 +31,7 @@ export function Checkbox({
 			<input
 				className="usa-checkbox__input"
 				id={id}
+				value={value}
 				type="checkbox"
 				defaultChecked={defaultValue}
 				onChange={onChange}


### PR DESCRIPTION
I'm slightly fuzzy on why this is important (maybe @jlhogan has a better understanding of what the Form stuff is doing under the hood) but basically checkbox needs a value prop that matches its key on the model.  This is handled at the checkboxgroup level for multiple checkboxes but needs to be addressed for single checkboxes.  We can't use a checkboxgroup for a single checkbox because it's wrapped in a fieldset and that would be weird and redundant.