### PR TITLE
Update DateInput to check for null default value

### DIFF
--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -39,7 +39,7 @@ export const DateInput: React.FC<DateInputProps> = ({
   };
 
   const [date, setDate] = useState<Moment | undefined>(
-    moment.utc(defaultValue)
+    defaultValue === null ? undefined  : moment.utc(defaultValue)
   );
 
   // Text input values


### PR DESCRIPTION
Currently, null default value results in date = invalid date moment
instance. Instead, we want to check if null default value is provided,
and have date = undefined. That allows for defaultValue = undefined to
correctly result in date = today moment instance, AND enabled the user
to define a no default value state