### PR TITLE
Translate and scale margins for close button to right side

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -43,7 +43,7 @@ export const Modal: React.FC<ModalProps> = ({
         )}
       >
         {header}
-        <div className={cx("oec-modal-close", "margin-right-2")}>
+        <div className="oec-modal-close">
           <Button
             appearance="unstyled"
             text={

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -43,12 +43,7 @@ export const Modal: React.FC<ModalProps> = ({
         )}
       >
         {header}
-        <div className="margin-right-2" style={{
-          position: 'relative',
-          top: '0%',
-          left: '0%',
-          transform: 'translate(50%, 0%)',
-          }}>
+        <div className={cx("oec-modal-close", "margin-right-2")}>
           <Button
             appearance="unstyled"
             text={

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -36,16 +36,20 @@ export const Modal: React.FC<ModalProps> = ({
         },
       }}
     >
-      <div className="margin-2">
-        <div
-          className={cx(
-            'grid-row display-flex flex-justify flex-align-center',
-            { 'border-bottom border-base-lighter': showHeaderBorder }
-          )}
-        >
-          {header}
+      <div
+        className={cx(
+          'grid-row display-flex flex-justify flex-align-center',
+          { 'border-bottom border-base-lighter': showHeaderBorder }
+        )}
+      >
+        {header}
+        <div className="margin-right-2" style={{
+          position: 'relative',
+          top: '0%',
+          left: '0%',
+          transform: 'translate(50%, 0%)',
+          }}>
           <Button
-            className="margin-bottom-2"
             appearance="unstyled"
             text={
               <div className="display-flex flex-column flex-align-center">
@@ -56,9 +60,9 @@ export const Modal: React.FC<ModalProps> = ({
             onClick={toggleOpen}
           />
         </div>
-        <div className={cx({ 'margin-top-2': showHeaderBorder })}>
-          {content}
-        </div>
+      </div>
+      <div className={cx({ 'margin-top-2': showHeaderBorder })}>
+        {content}
       </div>
     </ReactModal>
   );

--- a/src/components/Modal/_index.scss
+++ b/src/components/Modal/_index.scss
@@ -1,0 +1,6 @@
+.oec-modal-close {
+  position: 'relative',
+  top: '0%',
+  left: '0%',
+  transform: 'translate(50%, 0%)',
+}


### PR DESCRIPTION
Alters the styling in the div elements around the header of the modal and around the close button so that the button sits in the top-right corner of the modal while not overlapping the end of the header.

Closes ctoec/data-collection#501