### PR TITLE
Text input styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ctoec/component-library",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "React Component Library for OEC branded web applications",
   "homepage": "https://github.com/ctoec/component-library#readme",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ctoec/component-library",
-  "version": "1.0.13",
+  "version": "1.1.1",
   "description": "React Component Library for OEC branded web applications",
   "homepage": "https://github.com/ctoec/component-library#readme",
   "repository": {

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -160,6 +160,7 @@ export function TextInput({
         <input
           className={cx(
             'usa-input',
+            'oec-text-input',
             {
               [`usa-input--${status && status.type}`]: status,
             },

--- a/src/components/TextInput/_index.scss
+++ b/src/components/TextInput/_index.scss
@@ -1,4 +1,4 @@
 .oec-text-input:disabled {
-  background-color: rgb($theme-color-base-lighter);
-  border-color: rgb($theme-color-disabled-dark);
+  background-color: color($theme-color-base-lighter);
+  border-color: color($theme-color-disabled-dark);
 }

--- a/src/components/TextInput/_index.scss
+++ b/src/components/TextInput/_index.scss
@@ -1,0 +1,4 @@
+.oec-text-input:disabled {
+  background-color: rgb($theme-color-base-lighter);
+  border-color: rgb($theme-color-disabled-dark);
+}

--- a/src/components/_index.scss
+++ b/src/components/_index.scss
@@ -17,5 +17,6 @@
 @import './Table';
 @import './TabNav';
 @import './Tag';
+@import './TextInput/';
 @import './TextWithIcon';
 @import './TooltipWrapper';


### PR DESCRIPTION
Changes the styling for `TextInputs` that are disabled to be the same background and border color as disabled `Checkboxes` because it's a clearer visual indication that the field is disabled. Needed for https://github.com/ctoec/data-collection/pull/963 . Version number is incremented to be after Melanine's Modal PR since that will def land first.