### PR TITLE
Bump version number to republish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ctoec/component-library",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "React Component Library for OEC branded web applications",
   "homepage": "https://github.com/ctoec/component-library#readme",
   "repository": {


### PR DESCRIPTION
1.1.1 was published without the modal changes somehow, so needed to bump the version number to republish with those changes