### PR TITLE
Bump version to republish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ctoec/component-library",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "React Component Library for OEC branded web applications",
   "homepage": "https://github.com/ctoec/component-library#readme",
   "repository": {


### PR DESCRIPTION
For some reason the newest published version once again doesn't have the modal changes from a prior PR. We saw this issue before but don't know why it happened, but bumping version and re-publishing seemed to fix it :/