### PR TITLE
127 date input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ctoec/component-library",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "React Component Library for OEC branded web applications",
   "homepage": "https://github.com/ctoec/component-library#readme",
   "repository": {

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -73,7 +73,6 @@ export const DateInput: React.FC<DateInputProps> = ({
   }, [month, day, year]);
 
   useEffect(() => {
-    console.log(calendarDate);
     if (!calendarDate) return;
     setDate(calendarDate);
     setMonth(calendarDate.format('M'));

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -73,6 +73,7 @@ export const DateInput: React.FC<DateInputProps> = ({
   }, [month, day, year]);
 
   useEffect(() => {
+    console.log(calendarDate);
     if (!calendarDate) return;
     setDate(calendarDate);
     setMonth(calendarDate.format('M'));

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -76,16 +76,17 @@ export function TextInput({
   | TextInlineInputHTMLInputElementProps
   | TextInputHTMLTextAreaElementProps) {
   const [value, updateValue] = useState(
+    // Value overrides default value
     inputValue != null ? inputValue : defaultValue
   );
   useEffect(() => {
-    if (inputValue !== value) updateValue(inputValue);
+    // If input value is not null or undefined and it changes
+    if (inputValue != null && inputValue !== value) updateValue(inputValue);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [inputValue]);
 
   const onChange = (e: any) => {
     inputOnChange(e);
-    // If there isn't an input value, then this component should manage its own value
     updateValue(e.target.value);
   };
 

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import cx from 'classnames';
 import { FormStatus, FormStatusProps } from '..';
 
@@ -78,6 +78,10 @@ export function TextInput({
   const [value, updateValue] = useState(
     inputValue != null ? inputValue : defaultValue
   );
+  useEffect(() => {
+    if (inputValue !== value) updateValue(inputValue);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inputValue]);
 
   const onChange = (e: any) => {
     inputOnChange(e);


### PR DESCRIPTION
## Background
In most places in the app, we're using TextInput as an uncontrolled component. However, in the DateInput, we're using it like a controlled component. This change allows us to do both, with the value overriding the default value.

## GitHub Issue
#127 

## Associated PRs
Forthcoming PR to include published component library in data collection tool

## Additional Context
