### PR TITLE
Expose immutable update form data func so we can move away from super…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ctoec/component-library",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "React Component Library for OEC branded web applications",
   "homepage": "https://github.com/ctoec/component-library#readme",
   "repository": {

--- a/src/assets/styles/index.scss
+++ b/src/assets/styles/index.scss
@@ -11,7 +11,7 @@ $carbon--font-families: (
 ) !important;
 
 body {
-	font-family: 'Public Sans Web', 'Helvetica Neue', Arial, sans-serif
+  font-family: 'Public Sans Web', 'Helvetica Neue', Arial, sans-serif;
 }
 /*
 * * * * * ==============================

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -59,7 +59,7 @@ export function Button({
 
   if (href) {
     return (
-			<CarbonLink
+      <CarbonLink
         href={href}
         className={classString}
         onClick={onClick}

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -6,7 +6,9 @@ import React, {
 } from 'react';
 import cx from 'classnames';
 import { FormProvider } from './FormContext';
-import { ObjectDriller } from './ObjectDriller';
+import { ObjectDriller, TObjectDriller } from './ObjectDriller';
+import produce from 'immer';
+import set from 'lodash/set';
 
 export type FormProps<T> = {
   onSubmit: (_: T) => void;
@@ -26,7 +28,7 @@ export type FormProps<T> = {
  * The form tracks state of the object, and requires the use of a
  * 'submit' button (should be a FormSubmitButton)
  */
-export const Form = <T extends any>({
+export const Form = <T extends object>({
   className,
   onSubmit,
   data,
@@ -52,12 +54,24 @@ export const Form = <T extends any>({
     onSubmit(_data);
   };
 
+  const immutableUpdateData = <
+    TField extends string | number | boolean | undefined
+  >(
+    fieldDriller: TObjectDriller<TField>,
+    value: TField
+  ) => {
+    updateData(
+      produce<T>(data, (draft) => set(draft, fieldDriller.path, value))
+    );
+  };
+
   return (
     <FormProvider
       value={{
         data: _data,
         dataDriller: new ObjectDriller(_data),
         updateData,
+        immutableUpdateData,
         hideStatus,
       }}
     >

--- a/src/components/Form/FormContext.ts
+++ b/src/components/Form/FormContext.ts
@@ -17,6 +17,10 @@ export type FormContextType = {
   data: any;
   dataDriller: any;
   updateData: React.Dispatch<React.SetStateAction<any>>;
+  immutableUpdateData: (
+    _: TObjectDriller<string | number | boolean | undefined>,
+    __: any
+  ) => void;
   hideStatus?: boolean;
 };
 
@@ -31,6 +35,10 @@ export type GenericFormContextType<T> = {
   // Otherwise just passing the object would result in one of the updates being
   // overwritten.
   updateData: React.Dispatch<React.SetStateAction<T>>;
+  immutableUpdateData: (
+    _: TObjectDriller<string | number | boolean | undefined>,
+    __: any
+  ) => void;
   hideStatus?: boolean;
 };
 /**
@@ -47,6 +55,7 @@ export const FormContext = createContext<FormContextType>({
   data: undefined,
   dataDriller: undefined,
   updateData: (_) => {},
+  immutableUpdateData: (_, __) => {},
 });
 
 export const { Provider: FormProvider, Consumer: FormConsumer } = FormContext;


### PR DESCRIPTION
… complex formfields

## Background
Exposes the actually useful part of `FormField`, which is the path-based immutable object update wrapper func.
By exposing that, we can reduce complexity of the FE code by using vanilla form fields (i.e. carbon components for various html inputs) and wrapping them in our existing form (with form context)

## GitHub Issue
https://github.com/ctoec/data-collection/issues/1173

## Associated PRs
