### PR TITLE
Use useEffect to watch for change to `onChange` and date in DatePicker component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ctoec/component-library",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "React Component Library for OEC branded web applications",
   "homepage": "https://github.com/ctoec/component-library#readme",
   "repository": {

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -81,7 +81,6 @@ export const DateInput: React.FC<DateInputProps> = ({
     if (!val) {
       setDateString('');
       setDate(null);
-      onChange(null);
     } else {
       const newDate = moment(
         val.replaceAll('/', ''),
@@ -90,7 +89,6 @@ export const DateInput: React.FC<DateInputProps> = ({
       if (isValidDateString(val) && newDate.isValid()) {
         setDateString(newDate.format(momentFormat));
         setDate(newDate);
-        onChange(newDate);
       } else {
         setDateString(val);
       }
@@ -100,6 +98,10 @@ export const DateInput: React.FC<DateInputProps> = ({
   useEffect(() => {
     if (disabled) updateDate(null);
   }, [onChange, disabled]);
+
+  useEffect(() => {
+    onChange(date);
+  }, [onChange, date]);
 
   return (
     <FieldSet


### PR DESCRIPTION
## Background
Date value is lost when another component is changed. This change looks for change in onChange and resets the date.

## GitHub Issue
https://github.com/ctoec/component-library/issues/137

## Note
Recreated this PR https://github.com/ctoec/component-library/pull/149 with signed commits
