### PR TITLE
Add Search Bar component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ctoec/component-library",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "description": "React Component Library for OEC branded web applications",
   "homepage": "https://github.com/ctoec/component-library#readme",
   "repository": {

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import { Search } from 'carbon-components-react';
+import { Button } from '../Button/Button';
+
+type SearchProps = {
+  id: string;
+  labelText: string;
+  placeholderText: string;
+  onSearch: (query: string) => {};
+  className?: string;
+}
+
+export const SearchBar: React.FC<SearchProps> = ({
+  id,
+  labelText,
+  placeholderText,
+  onSearch,
+  className,
+}) => {
+  const [queryText, setQueryText] = useState("");
+  return (
+    <div className={className || ""}>
+      <Search
+        id={id}
+        labelText={labelText}
+        placeholder={placeholderText}
+        onChange={(e: any) => {
+          setQueryText(e.target.value);
+          return e.target.value;
+        }}
+      />
+      <Button
+        className="margin-top-2 margin-bottom-4"
+        text="Search"
+        onClick={() => onSearch(queryText)}
+        disabled={queryText === ""}
+      />
+    </div>
+  );
+};

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -15,11 +15,11 @@ export const SearchBar: React.FC<SearchProps> = ({
   labelText,
   placeholderText,
   onSearch,
-  className,
+  className = "",
 }) => {
   const [queryText, setQueryText] = useState("");
   return (
-    <div className={className || ""}>
+    <div className={className}>
       <Search
         id={id}
         labelText={labelText}


### PR DESCRIPTION
## Background
This changeset adds a basic search bar component that features a Carbon search component paired with our component library button. The search bar manages its own state in the text field and performs a given search function when the button is clicked.

## Associated PRs
https://github.com/ctoec/data-collection/pull/1341

## Additional Context
As discussed in the comments for the add user search PR, this ports almost exactly the same code that was formerly in the `CreateOrg` file into a reusable component, since we'll want to use this other places in the app.